### PR TITLE
fix: add contents write permission to GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

GitHub Actionsワークフローにタグプッシュに必要な権限を追加しました。

## Problem

PR #2 のワークフロー実行時に以下のエラーが発生：
```
remote: Permission to j4rviscmd/vscode-theme-solarized-deep.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/j4rviscmd/vscode-theme-solarized-deep/': The requested URL returned error: 403
```

## Solution

`.github/workflows/publish.yml` に `permissions.contents: write` を追加し、GitHub Actionsが以下の操作を実行できるようにしました：
- タグの作成とプッシュ
- GitHub Releaseの作成

## Changes

```yaml
jobs:
  publish:
    runs-on: ubuntu-latest
    permissions:
      contents: write  # 追加
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)