### PR TITLE
fix: update Node.js version to 20 for vsce compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Get version from package.json
         id: package-version


### PR DESCRIPTION
Node.js 18では`File` APIがサポートされておらず、vsceの実行時にエラーが発生するため、Node.js 20に更新しました。

Error fixed:
```
ReferenceError: File is not defined
    at Object.<anonymous> (/opt/hostedtoolcache/node/18.20.8/x64/lib/node_modules/@vscode/vsce/node_modules/undici/lib/web/webidl/index.js:531:48)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)