### PR TITLE
fix: change active tab border color to orange for better visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solarized-deep",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solarized-deep",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "engines": {
         "vscode": "^1.80.0"

--- a/themes/solarized-deep-color-theme.json
+++ b/themes/solarized-deep-color-theme.json
@@ -80,7 +80,7 @@
     "titleBar.border": "#000a0f",
     "tab.activeBackground": "#022030",
     "tab.activeForeground": "#93a1a1",
-    "tab.activeBorder": "#2aa198",
+    "tab.activeBorder": "#cb4b16",
     "tab.activeBorderTop": "#00000000",
     "tab.inactiveBackground": "#000a0f",
     "tab.inactiveForeground": "#839496",


### PR DESCRIPTION
## Summary
- Change active tab border color from Solarized cyan (`#2aa198`) to Solarized orange (`#cb4b16`) for improved tab visibility
- The orange border provides stronger visual contrast against the dark tab background, making the active tab immediately identifiable

## Test plan
- [x] Open multiple tabs and verify active tab underline is orange
- [x] Verify inactive tabs are visually distinct
- [x] Verify hover state remains functional
- [x] Confirm overall theme consistency is maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)