### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the "Solarized Deep" extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] - 2026-05-06
+
+### Fixed
+- Revert tab.activeBorder from orange (#cb4b16) back to cyan (#2aa198)
+- Darken statusBar.background from #000a0f to #000508 for better boundary visibility
+
+### Changed
+- Add CLAUDE.md to .gitignore and add .language file
+
 ## [0.1.5] - 2026-03-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "solarized-deep",
   "displayName": "Solarized Deep",
   "description": "A deeper, calmer dark theme based on Solarized Dark",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "publisher": "j4rviscmd",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Revert `tab.activeBorder` from orange (`#cb4b16`) back to cyan (`#2aa198`)
- Darken `statusBar.background` from `#000a0f` to `#000508` for better boundary visibility
- Add CLAUDE.md to `.gitignore` and add `.language` file

## What's Changed
- `fix: revert tab active border color to cyan and darken status bar` (#19)
- `chore: add CLAUDE.md to .gitignore and add .language file` (#20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)