### PR TITLE
chore: main ブランチへの直接 push をブロックする pre-push フックを追加

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,15 @@
+#!/bin/sh
+# pre-push: main ブランチへの直接 push をブロックする Git フック
+# main への変更は PR 経由でのみマージする運用を、ローカル側でも保護する目的。
+# 解除したい場合は git config --unset core.hooksPath を実行すること。
+
+while read -r local_ref local_oid remote_ref remote_oid; do
+	if [ "$remote_ref" = "refs/heads/main" ]; then
+		echo "[pre-push] main ブランチへの直接 push はブロックされました。" >&2
+		echo "[pre-push] main への変更は PR 経由でマージしてください。" >&2
+		echo "[pre-push] 保護を解除する場合: git config --unset core.hooksPath" >&2
+		exit 1
+	fi
+done
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Or install directly from the [Visual Studio Marketplace](https://marketplace.vis
 git clone https://github.com/j4rviscmd/vscode-theme-solarized-deep.git
 cd vscode-theme-solarized-deep
 
+# Enable shared Git hooks (blocks direct pushes to main)
+git config core.hooksPath .githooks
+
 # Copy to VSCode extensions directory
 cp -r . ~/.vscode/extensions/solarized-deep
 # or


### PR DESCRIPTION
## 概要

`main` ブランチへの直接 push を、ローカル・GUI ツール（coderm 等）含めて確実にブロックするため、リポジトリ共有の `pre-push` フックを導入します。

## 背景

`main` はブランチ保護されており直接 push は 100% 不可ですが、`.git/config` 単独では `git push origin main` のような明示的な push を確実に防げないため、フックによる保護が必要でした。

## 変更内容

- **`.githooks/pre-push`（新規）**: push 対象に `refs/heads/main` が含まれる場合に `exit 1` で拒否。明示的 push・`--force`・複数 ref 一括 push のいずれも防ぐ（実行権限 `100755` 付きでコミット）
- **`README.md`**: `Local Development & Testing` セクションに `git config core.hooksPath .githooks` の手順を追記

## 検証

- `main` ブランチの push → ブロック（exit 1）✓
- 他ブランチの push → 許可（exit 0）✓
- 今回の push（chore ブランチ）でフックが正常に通過することを実機確認済み

## セットアップ

clone 後、以下を実行すると有効化されます（README に記載）:

```bash
git config core.hooksPath .githooks
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)