### PR TITLE
fix: pre-push フックを courtesy guard として明文化し bypass 手順をエラー出力から削除

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,13 +1,14 @@
 #!/bin/sh
-# pre-push: main ブランチへの直接 push をブロックする Git フック
-# main への変更は PR 経由でのみマージする運用を、ローカル側でも保護する目的。
-# 解除したい場合は git config --unset core.hooksPath を実行すること。
+# pre-push: main ブランチへの直接 push をブロックする Git フック（うっかり防止）
+#
+# 注意: このフックは courtesy guard（開発者のうっかり直接 push を防ぐもの）であり、
+# セキュリティ境界ではありません。権威ある制御は GitHub のブランチ保護ルールです。
+# （git push --no-verify や core.hooksPath の変更で bypass 可能です）
 
 while read -r local_ref local_oid remote_ref remote_oid; do
 	if [ "$remote_ref" = "refs/heads/main" ]; then
 		echo "[pre-push] main ブランチへの直接 push はブロックされました。" >&2
 		echo "[pre-push] main への変更は PR 経由でマージしてください。" >&2
-		echo "[pre-push] 保護を解除する場合: git config --unset core.hooksPath" >&2
 		exit 1
 	fi
 done


### PR DESCRIPTION
## 概要

PR #24 で導入した `pre-push` フックに対する自動セキュリティレビューの指摘（3件）に対応します。

## 対応内容

| 指摘 | 重大度 | 対応 |
|------|--------|------|
| defense-in-depth: サーバー側ブランチ保護を推奨 | HIGH | GitHub ブランチ保護は既に設定済み（コンテキストで満たされている）。フックは courtesy guard として位置付けを明記 |
| エラーメッセージに bypass 手順を記載 | MEDIUM | bypass 手順をエラーメッセージから削除 |
| フックは courtesy guard として位置付ける | MEDIUM | ヘッダコメントに明記 |

## 変更内容

- **ヘッダコメント**: courtesy guard（うっかり防止）でありセキュリティ境界ではない旨、権威ある制御は GitHub のブランチ保護ルール、`--no-verify` / `core.hooksPath` 変更で bypass 可能である旨を明記
- **エラーメッセージ**: bypass 手順（`git config --unset core.hooksPath`）を削除。ブロックされた事実のみを出力

ブロック ロジック自体は変更なし（main → exit 1、他ブランチ → exit 0、動作検証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)