### PR TITLE
🚀 Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the "Solarized Deep" extension will be documented in this
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-08-02
+
+### ⚠️ Breaking Changes
+- depth 動的調整機能（`solarizedDeep.depth` 設定 + `extension/extension.js` による動的オーバーライド）を削除し、depth=100（Osaka パレット）固定の純粋な静的テーマに移行 (#26)
+  - `solarizedDeep.depth` 設定は削除され無視されます。従来の既定（depth=80）ユーザーは背景がやや明るくなります（`#001218` → `#00141a`）
+- titleBar / statusBar / activityBar をエディタ背景（`#00141a`）より暗く（`#000E14`）してフレーム境界を明確化 (#26)
+
+### Fixed
+- pre-push フックを courtesy guard として明文化し、bypass 手順をエラー出力から削除 (#25)
+
+### Changed
+- main ブランチへの直接 push をブロックする pre-push フックを追加 (#24)
+
 ## [0.2.0] - 2026-07-18
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solarized-deep",
-  "version": "0.1.5",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solarized-deep",
-      "version": "0.1.5",
+      "version": "0.3.0",
       "license": "MIT",
       "engines": {
         "vscode": "^1.80.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "solarized-deep",
   "displayName": "Solarized Deep",
   "description": "A deeper, calmer dark theme based on Solarized Dark",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "j4rviscmd",
   "icon": "icon.png",
   "license": "MIT",


### PR DESCRIPTION
## リリース v0.3.0

v0.2.0 → v0.3.0 のリリースです。

## 変更内容（CHANGELOG より）

### ⚠️ Breaking Changes
- depth 動的調整機能（`solarizedDeep.depth` 設定 + `extension/extension.js`）を削除し、depth=100（Osaka パレット）固定の純粋な静的テーマに移行 (#26)
- titleBar / statusBar / activityBar をエディタ背景より暗く（`#000E14`）してフレーム境界を明確化 (#26)

### Fixed
- pre-push フックを courtesy guard として明文化 (#25)

### Changed
- main ブランチへの直接 push をブロックする pre-push フックを追加 (#24)

## 含まれるファイル
- `package.json` / `package-lock.json`: バージョン `0.2.0` → `0.3.0`
- `CHANGELOG.md`: [0.3.0] エントリ追加

マージ後、GitHub Actions がタグ生成・GitHub Release・Marketplace 公開を自動実行します（手動操作不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)